### PR TITLE
Failure when installing freeimage from ports

### DIFF
--- a/ext/image_science/extconf.rb
+++ b/ext/image_science/extconf.rb
@@ -1,7 +1,7 @@
 require 'mkmf'
 
-include_path = '/usr/local/include:/usr/include'
-lib_path = '/usr/local/lib:/usr/lib'
+include_path = '/usr/local/include:/usr/include:/opt/local/include:/opt/include'
+lib_path = '/usr/local/lib:/usr/lib:/opt/local/lib:/opt/lib'
 
 dir_config("image_science", include_path, lib_path)
 


### PR DESCRIPTION
A few of us were getting errors when installing freeimage from ports due to freeimage being installed to /opt instead of /usr.
